### PR TITLE
feat (with): add with method

### DIFF
--- a/lib/rspecz.rb
+++ b/lib/rspecz.rb
@@ -3,6 +3,7 @@ if Module.const_defined?('RSpec::Core')
   require 'rspecz/contexts'
   require 'rspecz/subjects'
   require 'rspecz/lets'
+  require 'rspecz/with'
   require 'rspecz/aliases/behave'
   require 'rspecz/aliases/make'
 end

--- a/lib/rspecz/with.rb
+++ b/lib/rspecz/with.rb
@@ -1,0 +1,48 @@
+module RSpec
+  module Core
+    module MemoizedHelpers
+      module ClassMethods
+        class WithContext
+          attr_accessor :name, :values, :description, :block, :myobject
+
+          def initialize(name, values, block, myobject)
+            @name, @values, @block, @myobject = name, values, block, myobject
+          end
+
+          def desc(description)
+            @description = description
+            self
+          end
+
+          def so(&block)
+            continue_object = self
+            continue_object_block = @block
+            # TODO: create description from block.source
+            if @values.length > 0
+              raise RuntimeError.new("Syntax error you cannot set description by 'desc' method when you have multiple values set.") if @values.length > 1 && @description
+              @values.each do |value|
+                @myobject.context "when #{@name} is #{value}" do
+                  let(continue_object.name) { value }
+                  instance_exec(value, &block)
+                end
+              end
+            else
+              @myobject.context @description || "when #{@name} is different" do
+                if continue_object.name
+                  let(continue_object.name) { instance_eval(&continue_object_block) }
+                else
+                  before { instance_eval(&continue_object_block) }
+                end
+                instance_exec(&block)
+              end
+            end
+          end
+        end
+
+        def with(name = nil, *values, &block)
+          WithContext.new(name, values, block, self)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
fix https://github.com/RSpecZ/RSpecZ/issues/21

```
  # with one arg, define let with arg and block will be  value for it
  with(:name) { 'Mike' }.desc('This will be description for context').so do
    it { expect(name).to eq('Mike') }
  end

  # without args, block will be in before
  with { @name = 'mike' }.so do
    it { expect(@name).to eq('mike') }
  end

  # with multiple args, define let with first arg and make multiple contexts with args from second
  with(:name, 'test', 'jajaja').so do |value|
    it { expect(name).to eq(value) }
  end

  with(:name, 'Mike').desc('This will be description for context').so do
    it { expect(name).to eq('Mike') }
  end

  # with(:name, 'feakefa', 'afeaw').desc('feafe').so do
  #   it { expect(1).to eq(1) }
  # end
  # => this will occur error
```

after this merged. set_xxx methods will be deprecated.