### PR TITLE
fix bug of __get_description

### DIFF
--- a/lib/rspecz/with.rb
+++ b/lib/rspecz/with.rb
@@ -100,14 +100,21 @@ module RSpec
               end_word = start_word == '{' ? '}' : 'end'
 
               start_index = [bracket_start, do_start].min + start_word.length
+              inline_bracket_start = start_index
               next_end = 1
+              start_word_count = 0
+
               loop do
-                next_start = text[start_index..-1].index(start_word) || text.length
-                next_end = text[start_index..-1].index(end_word) || text.length
-                break if next_end < next_start
+                next_end = text[inline_bracket_start..-1].index(end_word) || text.length
+                start_word_count += text[inline_bracket_start..inline_bracket_start+next_end].scan(start_word).length
+                start_word_count -= 1
+                # binding.pry
+                break if start_word_count < 0
+                inline_bracket_start += next_end + 1
               end
-              text[start_index...start_index+next_end].split("\n").last.strip
-            rescue
+
+              text[start_index...inline_bracket_start+next_end].split("\n").last.strip
+            rescue => e
               p 'Warning: rspecz with __get_description failed...'
               'different'
             end


### PR DESCRIPTION
```
  with(:name) { 'test-name' }.and(:address) { 'test-address' }.so { it {
    expect(name).to eq('test-name')
    expect(address).to eq('test-address')
  } }
  with(:name) { { aa: 'test' }.with_indifferent_access }.so { it { expect(name[:aa]).to eq('test') } }
  with(:name) { { aa: { bb: 'test' }, test: { a: { b: 'test' } } }.with_indifferent_access }.so { it { expect(name[:aa][:bb]).to eq('test') } }
```
↓
```
  when name is 'test-name'
    and address is 'test-address'
      should eq "test-address"
  when name is { aa: 'test' }.with_indifferent_access
    should eq "test"
  when name is { aa: { bb: 'test' }, test: { a: { b: 'test' } } }.with_indifferent_access
    should eq "test"
```